### PR TITLE
remove all pause()

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-ALL_TARGETS := all base check install preinstall package rpm clean tutorial example
+ALL_TARGETS := all base check install preinstall package rpm clean tutorial
 MAKE_FILE := Makefile
 
 DEFAULT_BUILD_DIR := build
@@ -22,9 +22,6 @@ endif
 tutorial: all
 	make -C tutorial
 
-example: all
-	make -C example
-
 check: all
 	make -C test check
 
@@ -44,7 +41,6 @@ ifeq (build, $(wildcard build))
 endif
 	-make -C test clean
 	-make -C tutorial clean
-	-make -C example clean
 	rm -rf $(DEFAULT_BUILD_DIR)
 	rm -rf _include
 	rm -rf _lib

--- a/tutorial/tutorial-01-wget.cc
+++ b/tutorial/tutorial-01-wget.cc
@@ -17,7 +17,6 @@
 */
 
 #include <netdb.h>
-#include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -26,6 +25,7 @@
 #include "workflow/HttpMessage.h"
 #include "workflow/HttpUtil.h"
 #include "workflow/WFTaskFactory.h"
+#include "workflow/WFFacilities.h"
 
 #define REDIRECT_MAX    5
 #define RETRY_MAX       2
@@ -97,7 +97,12 @@ void wget_callback(WFHttpTask *task)
 	fprintf(stderr, "\nSuccess. Press Ctrl-C to exit.\n");
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -125,7 +130,8 @@ int main(int argc, char *argv[])
 	req->add_header_pair("User-Agent", "Wget/1.14 (linux-gnu)");
 	req->add_header_pair("Connection", "close");
 	task->start();
-	pause();
+
+	wait_group.wait();
 	return 0;
 }
 

--- a/tutorial/tutorial-02-redis_cli.cc
+++ b/tutorial/tutorial-02-redis_cli.cc
@@ -17,7 +17,6 @@
 */
 
 #include <netdb.h>
-#include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -25,6 +24,7 @@
 #include <string>
 #include "workflow/RedisMessage.h"
 #include "workflow/WFTaskFactory.h"
+#include "workflow/WFFacilities.h"
 
 #define RETRY_MAX       2
 
@@ -102,7 +102,12 @@ void redis_callback(WFRedisTask *task)
 	}
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -145,7 +150,8 @@ int main(int argc, char *argv[])
 	 * Workflow::start_series_work(task, nullptr) or
 	 * Workflow::create_series_work(task, nullptr)->start() */
 	task->start();
-	pause();
+
+	wait_group.wait();
 	return 0;
 }
 

--- a/tutorial/tutorial-04-http_echo_server.cc
+++ b/tutorial/tutorial-04-http_echo_server.cc
@@ -21,7 +21,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <signal.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -30,6 +29,7 @@
 #include "workflow/HttpUtil.h"
 #include "workflow/WFServer.h"
 #include "workflow/WFHttpServer.h"
+#include "workflow/WFFacilities.h"
 
 void process(WFHttpTask *server_task)
 {
@@ -92,7 +92,12 @@ void process(WFHttpTask *server_task)
 			addrstr, port, seq);
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -110,7 +115,7 @@ int main(int argc, char *argv[])
 	port = atoi(argv[1]);
 	if (server.start(port) == 0)
 	{
-		pause();
+		wait_group.wait();
 		server.stop();
 	}
 	else

--- a/tutorial/tutorial-05-http_proxy.cc
+++ b/tutorial/tutorial-05-http_proxy.cc
@@ -17,7 +17,6 @@
 */
 
 #include <signal.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <utility>
@@ -25,6 +24,7 @@
 #include "workflow/HttpMessage.h"
 #include "workflow/HttpUtil.h"
 #include "workflow/WFHttpServer.h"
+#include "workflow/WFFacilities.h"
 
 struct tutorial_series_context
 {
@@ -137,7 +137,12 @@ void process(WFHttpTask *proxy_task)
 	*series << http_task;
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -160,7 +165,7 @@ int main(int argc, char *argv[])
 
 	if (server.start(port) == 0)
 	{
-		pause();
+		wait_group.wait();
 		server.stop();
 	}
 	else

--- a/tutorial/tutorial-09-http_file_server.cc
+++ b/tutorial/tutorial-09-http_file_server.cc
@@ -27,6 +27,7 @@
 #include "workflow/WFHttpServer.h"
 #include "workflow/WFTaskFactory.h"
 #include "workflow/Workflow.h"
+#include "workflow/WFFacilities.h"
 
 using namespace protocol;
 
@@ -87,7 +88,12 @@ void process(WFHttpTask *server_task, const char *root)
 	}
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -113,7 +119,7 @@ int main(int argc, char *argv[])
 
 	if (ret == 0)
 	{
-		pause();
+		wait_group.wait();
 		server.stop();
 	}
 	else

--- a/tutorial/tutorial-10-user_defined_protocol/server.cc
+++ b/tutorial/tutorial-10-user_defined_protocol/server.cc
@@ -20,10 +20,10 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <signal.h>
-#include <unistd.h>
 #include "workflow/Workflow.h"
 #include "workflow/WFTaskFactory.h"
 #include "workflow/WFServer.h"
+#include "workflow/WFFacilities.h"
 #include "message.h"
 
 using WFTutorialTask = WFNetworkTask<protocol::TutorialRequest,
@@ -48,7 +48,12 @@ void process(WFTutorialTask *task)
 	resp->set_message_body(body, size);
 }
 
-void sig_handler(int signo) { }
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
 
 int main(int argc, char *argv[])
 {
@@ -70,7 +75,7 @@ int main(int argc, char *argv[])
 	if (server.start(AF_INET6, port) == 0 ||
 		server.start(AF_INET, port) == 0)
 	{
-		pause();
+		wait_group.wait();
 		server.stop();
 	}
 	else


### PR DESCRIPTION
- Remove ``example`` target from ``GNUmakefile``, avoid some error message when ``make clean``
- In ``tutorial`` folder, we can use ``WaitGroup`` but not ``pause()``, seem very nice :-)