### PR TITLE
opt code for ctor and dedup redefine for Task Callback

### DIFF
--- a/src/protocol/HttpUtil.cc
+++ b/src/protocol/HttpUtil.cc
@@ -54,13 +54,9 @@ bool HttpHeaderMap::key_exists(std::string key)
 
 std::string HttpHeaderMap::get(std::string key)
 {
-	std::transform(key.begin(), key.end(), key.begin(), ::tolower);
-	const auto it = header_map_.find(key);
-
-	if (it == header_map_.end() || it->second.empty())
-		return std::string();
-
-	return it->second[0];
+	std::string value;
+	get(std::move(key), value);
+	return value;
 }
 
 bool HttpHeaderMap::get(std::string key, std::string& value)

--- a/src/server/WFHttpServer.h
+++ b/src/server/WFHttpServer.h
@@ -24,7 +24,6 @@
 #include "WFServer.h"
 #include "WFTaskFactory.h"
 
-using http_process_t = std::function<void (WFHttpTask *)>;
 using WFHttpServer = WFServer<protocol::HttpRequest,
 							  protocol::HttpResponse>;
 
@@ -37,11 +36,10 @@ static constexpr struct WFServerParams HTTP_SERVER_PARAMS_DEFAULT =
 	.request_size_limit		=	(size_t)-1,
 	.ssl_accept_timeout		=	10 * 1000,
 };
-
+// http_callback_t defined in WFTaskFactory.h
 template<>
-inline WFHttpServer::WFServer(http_process_t proc) :
-	WFServerBase(&HTTP_SERVER_PARAMS_DEFAULT),
-	process(std::move(proc))
+inline WFHttpServer::WFServer(http_callback_t proc) :
+	WFServer(&HTTP_SERVER_PARAMS_DEFAULT, std::move(proc))
 {
 }
 

--- a/src/server/WFMySQLServer.cc
+++ b/src/server/WFMySQLServer.cc
@@ -45,7 +45,7 @@ CommConnection *WFMySQLServer::new_connection(int accept_fd)
 
 CommSession *WFMySQLServer::new_session(long long seq, CommConnection *conn)
 {
-	static mysql_process_t empty = [](WFMySQLTask *){ };
+	static mysql_callback_t empty = [](WFMySQLTask *){ };
 	WFMySQLTask *task;
 
 	task = WFServerTaskFactory::create_mysql_task(seq ? this->process : empty);

--- a/src/server/WFMySQLServer.h
+++ b/src/server/WFMySQLServer.h
@@ -25,7 +25,6 @@
 #include "WFTaskFactory.h"
 #include "WFConnection.h"
 
-using mysql_process_t = std::function<void (WFMySQLTask *)>;
 class MySQLServer;
 
 static constexpr struct WFServerParams MYSQL_SERVER_PARAMS_DEFAULT =
@@ -42,7 +41,7 @@ class WFMySQLServer : public WFServer<protocol::MySQLRequest,
 									  protocol::MySQLResponse>
 {
 public:
-	WFMySQLServer(mysql_process_t proc):
+	WFMySQLServer(mysql_callback_t proc):
 		WFServer(&MYSQL_SERVER_PARAMS_DEFAULT, std::move(proc))
 	{
 	}

--- a/src/server/WFRedisServer.h
+++ b/src/server/WFRedisServer.h
@@ -23,7 +23,6 @@
 #include "WFServer.h"
 #include "WFTaskFactory.h"
 
-using redis_process_t = std::function<void (WFRedisTask *)>;
 using WFRedisServer = WFServer<protocol::RedisRequest,
 							   protocol::RedisResponse>;
 
@@ -38,9 +37,8 @@ static constexpr struct WFServerParams REDIS_SERVER_PARAMS_DEFAULT =
 };
 
 template<>
-inline WFRedisServer::WFServer(redis_process_t proc) :
-	WFServerBase(&REDIS_SERVER_PARAMS_DEFAULT),
-	process(std::move(proc))
+inline WFRedisServer::WFServer(redis_callback_t proc) :
+	WFServer(&REDIS_SERVER_PARAMS_DEFAULT, std::move(proc))
 {
 }
 

--- a/src/server/WFServer.h
+++ b/src/server/WFServer.h
@@ -179,10 +179,9 @@ public:
 		process(std::move(proc))
 	{
 	}
-
+	// C++ support https://secure.wikimedia.org/wikipedia/en/wiki/C++11#Object_construction_improvement
 	WFServer(std::function<void (WFNetworkTask<REQ, RESP> *)> proc) :
-		WFServerBase(&SERVER_PARAMS_DEFAULT),
-		process(std::move(proc))
+		WFServer(&SERVER_PARAMS_DEFAULT, std::move(proc))
 	{
 	}
 

--- a/src/util/StringUtil.cc
+++ b/src/util/StringUtil.cc
@@ -218,7 +218,7 @@ std::string StringUtil::strip(const std::string& str)
 	return res;
 }
 
-bool StringUtil::start_with(const std::string &str, const std::string prefix)
+bool StringUtil::start_with(const std::string &str, const std::string& prefix)
 {
 	size_t prefix_len = prefix.size();
 

--- a/src/util/StringUtil.h
+++ b/src/util/StringUtil.h
@@ -36,7 +36,7 @@ public:
 	static std::string url_encode_component(const std::string& str);
 	static std::vector<std::string> split(const std::string& str, char sep);
 	static std::string strip(const std::string& str);
-	static bool start_with(const std::string &str, const std::string prefix);
+	static bool start_with(const std::string &str, const std::string& prefix);
 
 	//this will filter any empty result, so the result vector has no empty string
 	static std::vector<std::string> split_filter_empty(const std::string& str, char sep);


### PR DESCRIPTION
1. 去除冗余的process回调定义
2. 去除一些冗余的代码
3. 利用[C++11 Object_construction_improvement](https://secure.wikimedia.org/wikipedia/en/wiki/C++11#Object_construction_improvement) 精简构造函数
4. start_with 的prefix参数传引用