### PR TITLE
Update cmake process on window branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.6)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "build type")
-set(CMAKE_INSTALL_PREFIX /opt/sogou CACHE PATH "install prefix")
 set(CMAKE_SKIP_RPATH TRUE)
 
-project(workflow
-	VERSION 1.12.6
+project(
+	workflow
+	VERSION 0.9.1
 	LANGUAGES C CXX
 )
 
@@ -26,14 +26,13 @@ set(LIB_DIR ${PROJECT_SOURCE_DIR}/_lib CACHE PATH "workflow lib")
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIB_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIB_DIR})
-#set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LIB_DIR})
 
 add_custom_target(
 	LINK_HEADERS ALL
 	COMMENT "link headers..."
 )
 
-INCLUDE(CMakeLists_Headers.txt)
+include(CMakeLists_Headers.txt)
 
 macro(makeLink src dest target)
 	add_custom_command(
@@ -49,7 +48,6 @@ add_custom_command(
 )
 
 foreach(header_file ${INCLUDE_HEADERS} ${INCLUDE_KERNEL_HEADERS})
-	#file(COPY ${PROJECT_SOURCE_DIR}/${header_file} DESTINATION ${INC_DIR}/${PROJECT_NAME})
 	string(REPLACE "/" ";" arr ${header_file})
 	list(GET arr -1 file_name)
 	makeLink(${PROJECT_SOURCE_DIR}/${header_file} ${INC_DIR}/${PROJECT_NAME}/${file_name} LINK_HEADERS)
@@ -103,37 +101,6 @@ install(
 	RENAME ${PROJECT_NAME}-config.cmake
 )
 
-#### PACK
-
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Sogou C++ Workflow")
-set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
-
-# set(CPACK_RPM_PRE_INSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/pre_script.sh)
-# set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/post_script.sh)
-
-execute_process(
-	COMMAND git log -n1 --format=%ad --date=short
-	RESULT_VARIABLE GIT_LOG_RET
-	OUTPUT_VARIABLE GIT_YMD
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if (NOT GIT_LOG_RET EQUAL 0)
-	set(GIT_YMD 0)
-endif()
-
-string(REPLACE "-" "" RELEASE_LABEL ${GIT_YMD})
-set(CPACK_RPM_PACKAGE_RELEASE ${RELEASE_LABEL})
-
-set(CPACK_RPM_COMPONENT_INSTALL ON)
-set(CPACK_COMPONENTS_ALL devel)
-set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
-set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
-
-set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/lib64/cmake)
-
-set(CPACK_RPM_DEVEL_PACKAGE_REQUIRES "openssl-devel >= 1.0.1")
-
 install(
 	FILES ${INCLUDE_HEADERS} ${INCLUDE_KERNEL_HEADERS}
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
@@ -145,9 +112,3 @@ install(
 	DESTINATION "${CMAKE_INSTALL_DOCDIR}-${PROJECT_VERSION}"
 	COMPONENT devel
 )
-
-set(CPACK_RPM_SPEC_MORE_DEFINE "%define __spec_install_post /bin/true") # disable strip
-set(CPACK_GENERATOR "RPM")
-
-include(CPack)
-

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-ALL_TARGETS := all base check install preinstall package rpm clean tutorial example
+ALL_TARGETS := all base check install preinstall clean tutorial example
 MAKE_FILE := Makefile
 
 DEFAULT_BUILD_DIR := build
@@ -28,15 +28,10 @@ example: all
 check: all
 	make -C test check
 
-install preinstall package: base
+install preinstall: base
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && $(CMAKE3) $(ROOT_DIR)
 	make -C $(BUILD_DIR) -f Makefile $@
-
-rpm: package
-ifneq ($(BUILD_DIR),.)
-	mv $(BUILD_DIR)/*.rpm ./
-endif
 
 clean:
 ifeq (build, $(wildcard build))
@@ -48,10 +43,7 @@ endif
 	rm -rf $(DEFAULT_BUILD_DIR)
 	rm -rf _include
 	rm -rf _lib
-	rm -f SRCINFO SRCNUMVER SRCVERSION
-	rm -f ./*.rpm
 	find . -name CMakeCache.txt | xargs rm -f
 	find . -name Makefile       | xargs rm -f
 	find . -name "*.cmake"      | xargs rm -f
 	find . -name CMakeFiles     | xargs rm -rf
-


### PR DESCRIPTION
This PR does what #56 did, on branch windows to fix #54 .

+ Remove make package and make rpm because rpm is not portable.
+ #54 will be fixed naturally since CMakeLists.txt doesn't need any git information any more.
+ Remove manually set value of CMAKE_INSTALL_PREFIX. I think the default value is good enough.

Also, change version to 0.9.1.