### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(CMakeLists_Headers.txt)
 macro(makeLink src dest target)
 	add_custom_command(
 		TARGET ${target} PRE_BUILD
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${src} ${dest}
+		COMMAND ${CMAKE_COMMAND} -E copy ${src} ${dest}
 		DEPENDS ${dest}
 	)
 endmacro()


### PR DESCRIPTION
fix head create in cmake 3.11 and easy to copy _include and _lib to your own project.