### PR TITLE
Fix a bug with missing compilation independency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,10 @@ add_library(
 )
 
 if (KAFKA STREQUAL "y")
+	add_dependencies(client_kafka LINK_HEADERS)
+	add_dependencies(util_kafka LINK_HEADERS)
+	add_dependencies(protocol_kafka LINK_HEADERS)
+	add_dependencies(factory_kafka LINK_HEADERS)
 	add_library(
 		"wfkafka" STATIC
 		$<TARGET_OBJECTS:client_kafka>


### PR DESCRIPTION
Add missing `add_dependencies()` in src/CMakeLists.txt when `KAFKA=y`.