### PR TITLE
update android find openssl, suggesting set ssl path in cmake -DFLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.6)
 
-find_package(OpenSSL REQUIRED)
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+	find_package(OpenSSL REQUIRED)
+endif ()
+
 include_directories(${OPENSSL_INCLUDE_DIR} ${INC_DIR}/workflow)
 
 add_subdirectory(kernel)


### PR DESCRIPTION
suggestions for Android cross-compiling using cmake as toolchain file:
```sh
cmake -DOPENSSL_ROOT_DIR=/usr/local \
      -DOPENSSL_LIBRARIES=/usr/local/lib \
      -DOPENSSL_INCLUDE_DIR=/usr/local/include \
      ...
```