### PR TITLE
Add new create_series_work interface with only callback

### DIFF
--- a/src/factory/Workflow.cc
+++ b/src/factory/Workflow.cc
@@ -33,7 +33,9 @@ SeriesWork::SeriesWork(SubTask *first, series_callback_t&& cb) :
 	this->back = 0;
 	this->in_parallel = false;
 	this->canceled = false;
-	first->set_pointer(this);
+  if (first != nullptr) {
+    first->set_pointer(this);
+  }
 	this->first = first;
 	this->last = NULL;
 	this->context = NULL;
@@ -83,6 +85,9 @@ void SeriesWork::expand_queue()
 void SeriesWork::push_front(SubTask *task)
 {
 	this->mutex.lock();
+  if (this->first == nullptr) {
+    this->first = task;
+  }
 	if (--this->front == -1)
 		this->front = this->queue_size - 1;
 
@@ -97,6 +102,9 @@ void SeriesWork::push_front(SubTask *task)
 void SeriesWork::push_back(SubTask *task)
 {
 	this->mutex.lock();
+  if (this->first == nullptr) {
+    this->first = task;
+  }
 	task->set_pointer(this);
 	this->queue[this->back] = task;
 	if (++this->back == this->queue_size)

--- a/src/factory/Workflow.h
+++ b/src/factory/Workflow.h
@@ -38,6 +38,9 @@ public:
 	static SeriesWork *
 	create_series_work(SubTask *first, series_callback_t callback);
 
+	static SeriesWork *
+	create_series_work(series_callback_t callback);
+
 	static void
 	start_series_work(SubTask *first, series_callback_t callback);
 
@@ -163,6 +166,12 @@ inline SeriesWork *
 Workflow::create_series_work(SubTask *first, series_callback_t callback)
 {
 	return new SeriesWork(first, std::move(callback));
+}
+
+inline SeriesWork *
+Workflow::create_series_work(series_callback_t callback)
+{
+	return new SeriesWork(nullptr, std::move(callback));
 }
 
 inline void


### PR DESCRIPTION
Sometimes only want to create series without task and add the tasks afterwards.

It may be safer to add empty_task for the new interface, while it's complex for me to fix the dependency problems. 