### PR TITLE
fix crash on Windows branch for use session after deleted

### DIFF
--- a/src/kernel_win/Communicator.cc
+++ b/src/kernel_win/Communicator.cc
@@ -919,6 +919,7 @@ void Communicator::handle_incoming_request(struct poller_result *res)
 			{
 				ctx = NULL;//reuse context
 				entry->state = CONN_STATE_IDLE;
+				entry->session = NULL;
 				list_add(&entry->list, &target->idle_list);
 				break;
 			}
@@ -1018,6 +1019,7 @@ void Communicator::handle_incoming_reply(struct poller_result *res)
 				{
 					ctx = NULL;//reuse context
 					entry->state = CONN_STATE_IDLE;
+					entry->session = NULL;
 					list_add(&entry->list, &target->idle_list);
 					break;
 				}
@@ -1228,7 +1230,6 @@ void Communicator::handle_request_result(struct poller_result *res)
 	switch (res->state)
 	{
 	case PR_ST_SUCCESS:
-	case PR_ST_FINISHED:
 		do
 		{
 			if (nleft >= buffer->len)
@@ -1298,7 +1299,7 @@ void Communicator::handle_request_result(struct poller_result *res)
 		}
 
 		break;
-
+	case PR_ST_FINISHED:
 	case PR_ST_ERROR:
 	case PR_ST_TIMEOUT:
 		cs_state = CS_STATE_ERROR;

--- a/src/kernel_win/Communicator.cc
+++ b/src/kernel_win/Communicator.cc
@@ -919,7 +919,6 @@ void Communicator::handle_incoming_request(struct poller_result *res)
 			{
 				ctx = NULL;//reuse context
 				entry->state = CONN_STATE_IDLE;
-				entry->session = NULL;
 				list_add(&entry->list, &target->idle_list);
 				break;
 			}

--- a/src/kernel_win/WinPoller.cc
+++ b/src/kernel_win/WinPoller.cc
@@ -490,8 +490,13 @@ int WinPoller::get_io_result(struct poller_result *res, int timeout)
 	}
 	else if (bytes_transferred == 0)
 	{
-		res->state = PR_ST_FINISHED;
-		res->error = ECONNRESET;
+		res->error = GetLastError();
+		if (res->error == ERROR_OPERATION_ABORTED)
+			res->state = PR_ST_STOPPED;
+		else if (res->error == ERROR_SUCCESS)
+			res->state = PR_ST_SUCCESS;
+		else
+			res->state = PR_ST_FINISHED;
 	}
 	else
 	{


### PR DESCRIPTION
1. When state set to CONN_STATE_IDLE，session will delete later, set entry->session to NULL can make sure session won't be use again.
2. Optimize the TCP RST situation