### PR TITLE
Revert last modification about "bytes_transferred == 0" (windows)

### DIFF
--- a/src/kernel_win/Communicator.cc
+++ b/src/kernel_win/Communicator.cc
@@ -1229,6 +1229,7 @@ void Communicator::handle_request_result(struct poller_result *res)
 	switch (res->state)
 	{
 	case PR_ST_SUCCESS:
+	case PR_ST_FINISHED:
 		do
 		{
 			if (nleft >= buffer->len)
@@ -1298,7 +1299,7 @@ void Communicator::handle_request_result(struct poller_result *res)
 		}
 
 		break;
-	case PR_ST_FINISHED:
+
 	case PR_ST_ERROR:
 	case PR_ST_TIMEOUT:
 		cs_state = CS_STATE_ERROR;

--- a/src/kernel_win/WinPoller.cc
+++ b/src/kernel_win/WinPoller.cc
@@ -490,13 +490,8 @@ int WinPoller::get_io_result(struct poller_result *res, int timeout)
 	}
 	else if (bytes_transferred == 0)
 	{
-		res->error = GetLastError();
-		if (res->error == ERROR_OPERATION_ABORTED)
-			res->state = PR_ST_STOPPED;
-		else if (res->error == ERROR_SUCCESS)
-			res->state = PR_ST_SUCCESS;
-		else
-			res->state = PR_ST_FINISHED;
+		res->state = PR_ST_FINISHED;
+		res->error = ECONNRESET;
 	}
 	else
 	{


### PR DESCRIPTION
Revert some code in order to solve the memory issue, this is not the best solution, but it's better