### PR TITLE
add NDK (Android) build support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.6)
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+if(ANDROID)
+	include_directories(${OPENSSL_INCLUDE_DIR})
+	link_directories(${OPENSSL_LINK_DIR})
+else()
 	find_package(OpenSSL REQUIRED)
 endif ()
 
@@ -66,6 +69,8 @@ add_library(
 
 if (APPLE)
 	target_link_libraries(${SHARED_LIB_NAME} OpenSSL::SSL OpenSSL::Crypto pthread)
+elseif(ANDROID)
+	target_link_libraries(${SHARED_LIB_NAME} ssl crypto c)
 endif ()
 
 set_target_properties(${STATIC_LIB_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -8,8 +8,12 @@ project(tutorial
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-find_library(LIBRT rt)
-find_package(OpenSSL REQUIRED)
+if(ANDROID)
+	link_directories(${OPENSSL_LINK_DIR})
+else()
+	find_library(LIBRT rt)
+	find_package(OpenSSL REQUIRED)
+endif()
 find_package(workflow REQUIRED CONFIG HINTS ..)
 include_directories(${OPENSSL_INCLUDE_DIR} ${WORKFLOW_INCLUDE_DIR})
 link_directories(${WORKFLOW_LIB_DIR})
@@ -43,6 +47,8 @@ set(TUTORIAL_LIST
 
 if (APPLE)
 	set(WORKFLOW_LIB workflow pthread OpenSSL::SSL OpenSSL::Crypto)
+elseif (ANDROID)
+	set(WORKFLOW_LIB workflow ssl crypto c)
 else ()
 	set(WORKFLOW_LIB workflow pthread OpenSSL::SSL OpenSSL::Crypto ${LIBRT})
 endif ()


### PR DESCRIPTION
原本的 CMakeLists 已经比较完整了，只需要略微调整一下就可以支持 NDK (Android) 编译。
主要有 3 点

1. NDK 里面 pthread 和 librt 都在 libc 这个库里面
2. NDK 不预置 openssl ，编译时需要单独提供 ssl 库。
3. 使用NDK需要传入相应的安卓配置信息，比如平台和版本以及导入NDK的 cmakefile。

ssl 库的编译方式可以参考我仓库里面的 [build_android.sh](https://github.com/BDZNH/workflow-android/blob/master/build_android.sh)，kafka 的部分我这里没有环境所以没有验证。

另附：之前我用 NDK 编译的时候是需要显式链接 libc 的，今天试了一下又不用了。可能这中间你们的一些修改影响了这里，不过为了方便与链接了 pthread 的平台做对比，还是保留了 libc 。