### PR TITLE
optimize consistent_hash with map

### DIFF
--- a/src/nameservice/UpstreamPolicies.h
+++ b/src/nameservice/UpstreamPolicies.h
@@ -13,13 +13,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  Authors: Wu Jiaxu (wujiaxu@sogou-inc.com)
+  Authors: Li Yingxin (liyingxin@sogou-inc.com)
+           Wang Zhulei (wangzhulei@sogou-inc.com)
 */
 
 #ifndef _UPSTREAMPOLICIES_H_
 #define _UPSTREAMPOLICIES_H_
 
 #include <utility>
+#include <map>
 #include <vector>
 #include <functional>
 #include "URIParser.h"
@@ -39,7 +41,6 @@ public:
 	short server_type;
 	int group_id;
 	EndpointGroup *group;
-	unsigned int consistent_hash[VIRTUAL_GROUP_SIZE];
 
 	UPSAddrParams(const struct AddressParams *params,
 				  const std::string& address);
@@ -71,12 +72,16 @@ protected:
 	virtual void add_server_locked(EndpointAddress *addr);
 	virtual int remove_server_locked(const std::string& address);
 
-	EndpointAddress *consistent_hash_with_group(unsigned int hash,
-												WFNSTracing *tracing);
 	EndpointAddress *check_and_get(EndpointAddress *addr,
 								   bool addr_failed, WFNSTracing *tracing);
 
 	bool is_alive(const EndpointAddress *addr) const;
+
+protected:
+	EndpointAddress *consistent_hash_with_group(unsigned int hash,
+												WFNSTracing *tracing);
+
+	std::map<unsigned int, EndpointAddress *> addr_hash;
 };
 
 class UPSWeightedRandomPolicy : public UPSGroupPolicy
@@ -139,6 +144,8 @@ protected:
 									WFNSTracing *tracing);
 
 private:
+	virtual void add_server_locked(EndpointAddress *addr);
+	virtual int remove_server_locked(const std::string& address);
 	upstream_route_t consistent_hash;
 };
 
@@ -159,6 +166,8 @@ public:
 									  WFNSTracing *tracing);
 
 private:
+	virtual void add_server_locked(EndpointAddress *addr);
+	virtual int remove_server_locked(const std::string& address);
 	upstream_route_t manual_select;
 	upstream_route_t another_select;
 };

--- a/test/upstream_unittest.cc
+++ b/test/upstream_unittest.cc
@@ -73,7 +73,7 @@ void register_upstream_hosts()
 	},
 	true,
 	[](const char *path, const char *query, const char *fragment) -> unsigned int {
-		return 1; // according to consistent_hash this will hit server[0]
+		return 511702306; // according to consistent_hash this will hit server[0]
 	});
 	UpstreamManager::upstream_add_server("manual", "127.0.0.1:8001");
 	UpstreamManager::upstream_add_server("manual", "127.0.0.1:8002");


### PR DESCRIPTION
Also shrinks the memory of policies those do not use consistent hash.
Unittest can cover the case of skipping not alive servers in select().