### PR TITLE
Fix WFServiceGorvernance::copy_host_port()

### DIFF
--- a/src/nameservice/WFServiceGovernance.cc
+++ b/src/nameservice/WFServiceGovernance.cc
@@ -69,13 +69,13 @@ public:
 
 static void copy_host_port(ParsedURI& uri, const EndpointAddress *addr)
 {
-	if (addr->host != uri.host)
+	if (!addr->host.empty() && addr->host != uri.host)
 	{
 		free(uri.host);
 		uri.host = strdup(addr->host.c_str());
 	}
 
-	if (addr->port != uri.port)
+	if (!addr->port.empty() && addr->port != uri.port)
 	{
 		free(uri.port);
 		uri.port = strdup(addr->port.c_str());


### PR DESCRIPTION
When using upstream with port and upstream_add_server() without port, it's supposed to use the upstream port when requsting.
This is a bug introduced few months ago. Thanks @kedixa for reminding.