### PR TITLE
--pool->nthreads and singal too ealy, the pthreadjoin maybe not not executed

### DIFF
--- a/src/kernel/thrdpool.c
+++ b/src/kernel/thrdpool.c
@@ -82,12 +82,13 @@ static void *__thrdpool_routine(void *arg)
 	/* One thread joins another. Don't need to keep all thread IDs. */
 	tid = pool->tid;
 	pool->tid = pthread_self();
-	if (--pool->nthreads == 0)
-		pthread_cond_signal(pool->terminate);
 
 	pthread_mutex_unlock(&pool->mutex);
 	if (memcmp(&tid, &__zero_tid, sizeof (pthread_t)) != 0)
 		pthread_join(tid, NULL);
+	
+	if (--pool->nthreads == 0)
+		pthread_cond_signal(pool->terminate);
 
 	return NULL;
 }


### PR DESCRIPTION
在线程结束前过早的调用了 --pool->nthreads 并 signal，存在主线程提前检测到线程数量为 0，部分线程没被 join 到的情况。