### PR TITLE
add bootstrap tutorial to gracefully restart server

### DIFF
--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TUTORIAL_LIST
 	tutorial-09-http_file_server
 	tutorial-11-graph_task
 	tutorial-15-name_service
+	tutorial-16-bootstrap_server
 	tutorial-17-dns_cli
 	tutorial-20-reducer
 )
@@ -101,3 +102,5 @@ set_target_properties(server PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/${DIR10})
 set_target_properties(client PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/${DIR10})
+
+add_executable(bootstrap_daemon tutorial-16-bootstrap_daemon.c)

--- a/tutorial/tutorial-16-bootstrap_daemon.c
+++ b/tutorial/tutorial-16-bootstrap_daemon.c
@@ -1,0 +1,113 @@
+/*
+  Copyright (c) 2022 Sogou, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: Li Yingxin (liyingxin@sogou-inc.com)
+*/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <signal.h>
+
+void sig_handler(int signo) { }
+
+int main(int argc, const char *argv[])
+{
+	if (argc != 3)
+	{
+		fprintf(stderr, "USAGE: %s EXEC_PROCESS PORT\n"
+				"Bootstrap for workflow server to restart gracefully.\n",
+				argv[0]);
+		exit(1);
+	}
+
+	unsigned short port = atoi(argv[2]);
+	int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+	struct sockaddr_in sin;
+
+	memset(&sin, 0, sizeof sin);
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	sin.sin_addr.s_addr = htonl(INADDR_ANY);
+
+	if (bind(listen_fd, (struct sockaddr *)&sin, sizeof sin) < 0)
+	{
+		close(listen_fd);
+		perror("bind error");
+		exit(1);
+	}
+
+	pid_t pid;
+	int pipe_fd[2];
+	ssize_t len;
+	char buf[100];
+	char cmd[10] = { 0 };
+
+	char listen_fd_str[10] = { 0 };
+	char write_fd_str[10] = { 0 };
+	sprintf(listen_fd_str, "%d", listen_fd);
+
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+
+	while (strlen(cmd) == 0 || strncmp(cmd, "restart", strlen("restart")) == 0)
+	{
+		memset(cmd, 0, sizeof cmd);
+		if (pipe(pipe_fd) == -1)
+		{
+			perror("open pipe error");
+			exit(1);
+		}
+
+		memset(write_fd_str, 0, sizeof write_fd_str);
+		sprintf(write_fd_str, "%d", pipe_fd[1]);
+
+		pid = fork();
+		if (pid < 0)
+		{
+			perror("fork error");
+			close(pipe_fd[0]);
+			close(pipe_fd[1]);
+			break;
+		}
+		else if (pid == 0)
+		{
+			close(pipe_fd[0]);
+			execlp(argv[1], argv[1], listen_fd_str, write_fd_str, NULL);
+		}
+		else
+		{
+			close(pipe_fd[1]);
+			signal(SIGCHLD, SIG_IGN);
+			fprintf(stderr, "Bootstrap daemon command [restart|stop] ? : ");
+			fgets(cmd, 100, stdin);
+
+			kill(pid, SIGUSR1);
+			fprintf(stderr, "SIGUSR1 to pid-%ld and restarting.\n", (long)pid);
+			len = read(pipe_fd[0], buf, 7);
+			fprintf(stderr, "Bootstrap server served %*s.\n", (int)len, buf);
+			close(pipe_fd[0]);
+		}
+	}
+
+	close(listen_fd);
+	return 0;
+}
+

--- a/tutorial/tutorial-16-bootstrap_server.cc
+++ b/tutorial/tutorial-16-bootstrap_server.cc
@@ -1,0 +1,68 @@
+/*
+  Copyright (c) 2022 Sogou, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: Li Yingxin (liyingxin@sogou-inc.com)
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include "workflow/WFFacilities.h"
+#include "workflow/WFHttpServer.h"
+
+static WFFacilities::WaitGroup wait_group(1);
+
+void sig_handler(int signo)
+{
+	wait_group.done();
+}
+
+int main(int argc, const char *argv[])
+{
+	if (argc != 3)
+	{
+		fprintf(stderr, "USAGE: %s listen_fd pipe_fd\n", argv[0]);
+		exit(1);
+	}
+
+	int listen_fd = atoi(argv[1]);
+	int pipe_fd = atoi(argv[2]);
+
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+	signal(SIGUSR1, sig_handler);
+
+	WFHttpServer server([](WFHttpTask *task) {
+     	task->get_resp()->append_output_body("<html>Hello World!</html>");
+	});
+
+	if (server.serve(listen_fd) == 0)
+	{
+		wait_group.wait();
+		server.shutdown();
+		write(pipe_fd, "success", strlen("success"));
+		close(pipe_fd);
+		server.wait_finish();
+
+		return 0;
+	}
+
+	write(pipe_fd, "failed ", strlen("failed "));
+	close(pipe_fd);
+
+    return 0;
+}
+


### PR DESCRIPTION
Terminal-1 :
~~~sh
[@gdylj_35_53 tutorial]# ./bootstrap_daemon ./bootstrap_server 1412
Bootstrap daemon command [restart|stop] ? : restart
SIGUSR1 to pid-32349 and restarting.
Bootstrap server served success.
Bootstrap daemon command [restart|stop] ? : restart
SIGUSR1 to pid-32375 and restarting.
Bootstrap server served success.
Bootstrap daemon command [restart|stop] ? : stop
SIGUSR1 to pid-32407 and restarting.
Bootstrap server served success.
~~~

Terminal-2 :
~~~sh
[@gdylj_35_53 ~]# ab -c 10 -n 200000  localhost:1412/
This is ApacheBench, Version 2.3 <$Revision: 1430300 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 20000 requests
Completed 40000 requests
Completed 60000 requests
Completed 80000 requests
Completed 100000 requests
Completed 120000 requests
Completed 140000 requests
Completed 160000 requests
Completed 180000 requests
Completed 200000 requests
Finished 200000 requests


Server Software:        
Server Hostname:        localhost
Server Port:            1412

Document Path:          /
Document Length:        25 bytes

Concurrency Level:      10
Time taken for tests:   6.526 seconds
Complete requests:      200000
Failed requests:        0
Write errors:           0
Total transferred:      16600000 bytes
HTML transferred:       5000000 bytes
Requests per second:    30644.88 [#/sec] (mean)
Time per request:       0.326 [ms] (mean)
Time per request:       0.033 [ms] (mean, across all concurrent requests)
Transfer rate:          2483.91 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:     0    0   0.0      0       4
Waiting:        0    0   0.0      0       4
Total:          0    0   0.0      0       4

Percentage of the requests served within a certain time (ms)
  50%      0
  66%      0
  75%      0
  80%      0
  90%      0
  95%      0
  98%      0
  99%      0
 100%      4 (longest request)
~~~