### PR TITLE
added support for openssl-3.0

### DIFF
--- a/src/util/MD5Util.cc
+++ b/src/util/MD5Util.cc
@@ -16,17 +16,33 @@
   Authors: Wu Jiaxu (wujiaxu@sogou-inc.com)
 */
 
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#include <openssl/evp.h>
+#else
 #include <openssl/md5.h>
+#endif
+
 #include <string.h>
 #include <string>
 #include "MD5Util.h"
 
 static inline void __md5(const std::string& str, unsigned char *md)
 {
-	MD5_CTX ctx;
-	MD5_Init(&ctx);
-	MD5_Update(&ctx, str.c_str(), str.size());
-	MD5_Final(md, &ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    EVP_MD_CTX *mdctx;
+    const EVP_MD *md_type = EVP_get_digestbyname("md5");
+    mdctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex2(mdctx, md_type, nullptr);
+    EVP_DigestUpdate(mdctx, str.c_str(), str.size());
+    EVP_DigestFinal_ex(mdctx, md, nullptr);
+    EVP_MD_CTX_free(mdctx);
+# else
+    MD5_CTX ctx;
+    MD5_Init(&ctx);
+    MD5_Update(&ctx, str.c_str(), str.size());
+    MD5_Final(md, &ctx);
+#endif
 }
 
 std::string MD5Util::md5_bin(const std::string& str)


### PR DESCRIPTION
MD5_Init/MD5_Update/MD5_Final/SHA1_Init/SHA1_Update/SHA1_Final are marked deprecated in openssl-3.0

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/17794695/175822815-78789aee-4c04-47a3-8518-44532a39a5b2.png">
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/17794695/175822842-06ed08c7-84c2-4b6f-8bf3-adb7fa2d73ef.png">


FYI: [Why "old" digest functions are deprecated?](https://github.com/openssl/openssl/issues/12260)

Besides, when used as **Collision Resistant Hash Functions**, the security of MD5 and SHA-1 should be reconsidered.

For security issues, I need to further read the relevant implementation.
