### PR TITLE
添加接受topic/partition/offset作为参数的add_commit_record重载

### DIFF
--- a/src/client/WFKafkaClient.h
+++ b/src/client/WFKafkaClient.h
@@ -49,6 +49,15 @@ public:
 
 	virtual bool add_offset_toppar(const protocol::KafkaToppar& toppar) = 0;
 
+	void add_commit_record(const std::string& topic, int partition, long long offset)
+	{
+		protocol::KafkaToppar toppar;
+		toppar.set_topic_partition(topic, partition);
+		toppar.set_offset(offset);
+		toppar.set_error(0);
+		this->toppar_list.add_item(std::move(toppar));
+	}
+
 	void add_commit_record(const protocol::KafkaRecord& record)
 	{
 		protocol::KafkaToppar toppar;
@@ -169,4 +178,3 @@ private:
 };
 
 #endif
-

--- a/src/client/WFKafkaClient.h
+++ b/src/client/WFKafkaClient.h
@@ -49,15 +49,6 @@ public:
 
 	virtual bool add_offset_toppar(const protocol::KafkaToppar& toppar) = 0;
 
-	void add_commit_record(const std::string& topic, int partition, long long offset)
-	{
-		protocol::KafkaToppar toppar;
-		toppar.set_topic_partition(topic, partition);
-		toppar.set_offset(offset);
-		toppar.set_error(0);
-		this->toppar_list.add_item(std::move(toppar));
-	}
-
 	void add_commit_record(const protocol::KafkaRecord& record)
 	{
 		protocol::KafkaToppar toppar;
@@ -74,6 +65,15 @@ public:
 		toppar_t.set_offset(toppar.get_offset());
 		toppar_t.set_error(0);
 		this->toppar_list.add_item(std::move(toppar_t));
+	}
+
+	void add_commit_item(const std::string& topic, int partition, long long offset)
+	{
+		protocol::KafkaToppar toppar;
+		toppar.set_topic_partition(topic, partition);
+		toppar.set_offset(offset);
+		toppar.set_error(0);
+		this->toppar_list.add_item(std::move(toppar));
 	}
 
 	void set_api_type(int api_type)
@@ -178,3 +178,4 @@ private:
 };
 
 #endif
+


### PR DESCRIPTION
现在的 offset 提交接口，只接受 KafkaRecord/KafkaToppar 对象作为参数，这就导致手动提交offset的场景下，必须缓存 KafkaRecord/KafkaToppar。

而实际上，提交 offset 只需要 topic/partition/offset 三个参数就够了。