### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ To install the Workflow library for deployment:
 sudo apt-get install libworkflow1
 ~~~~
 
+### Get started (vcpkg):
+vcpkg is a full platform package manager, you can easily install workflow with vcpkg:
+~~~sh
+git clone https://github.com/microsoft/vcpkg.git
+./bootstrap-vcpkg.bat # For powershell
+./bootstrap-vcpkg.sh # For bash
+./vcpkg install workflow
+~~~
+
 # Tutorials
 
 * Client

--- a/README_cn.md
+++ b/README_cn.md
@@ -67,6 +67,15 @@ sudo apt-get install workflow1
 ~~~
 注意Ubuntu Linux只有最新22.04版自带workflow。更推荐用git直接下载最新源代码编译。
 
+#### 快速开始(vcpkg)
+vcpkg是一个支持全平台的包管理器，你可以使用vcpkg轻松的编译与安装workflow：
+~~~sh
+git clone https://github.com/microsoft/vcpkg.git
+./bootstrap-vcpkg.bat # For powershell
+./bootstrap-vcpkg.sh # For bash
+./vcpkg install workflow
+~~~
+
 # 示例教程
   * Client基础
     * [创建第一个任务：wget](docs/tutorial-01-wget.md)


### PR DESCRIPTION
`workflow` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `workflow` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `workflow`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/workflow/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)

