### PR TITLE
websocket: support wss

### DIFF
--- a/src/client/WFWebSocketClient.cc
+++ b/src/client/WFWebSocketClient.cc
@@ -51,6 +51,8 @@ int WebSocketClient::init(const struct WFWebSocketParams *params)
 	this->channel->set_uri(uri);
 	this->channel->set_idle_timeout(params->idle_timeout);
 	this->channel->set_size_limit(params->size_limit);
+	if (uri.scheme && strcasecmp(uri.scheme, "wss") == 0)
+		this->channel->set_transport_type(TT_TCP_SSL);
 
 	if (params->sec_protocol)
 		this->channel->set_sec_protocol(params->sec_protocol);

--- a/tutorial/tutorial-14-websocket_cli.cc
+++ b/tutorial/tutorial-14-websocket_cli.cc
@@ -48,7 +48,9 @@ int main(int argc, char *argv[])
 {
 	if (argc != 2)
 	{
-		fprintf(stderr, "USAGE: %s <url>\n	url format: ws://host:ip\n", argv[0]);
+		fprintf(stderr, "USAGE: %s <url>\n"
+				" url format: ws://host:ip\n"
+				"             wss://host:ip\n", argv[0]);
 		return 0;
 	}
 


### PR DESCRIPTION
Tested with gorilla websocket http echo server.

write a file my_server.go and execute:
```
go run my_server.go 
```
execute workflow websocket client:
```
./websocket_cli wss://localhost:8080
```
server output:
```
recv: This is Workflow websocket client.
read: websocket: close 1005 (no status)
```
client output:
```
send callback() state=0 error=0
get text message: [This is Workflow websocket client.]
process opcode=10
```

P.S. a simple wss server with gorilla/websocket:
```
package main                                                                    
                                                                                
import (                                                                        
    "flag"                                                                      
    "log"                                                                       
    "net/http"                                                                  
                                                                                
    "github.com/gorilla/websocket"                                              
)                                                                               
                                                                                
var addr = flag.String("addr", "localhost:8080", "http service address")        
                                                                                
var upgrader = websocket.Upgrader{} // use default options                      
                                                                                
func main() {                                                                   
    flag.Parse()                                                                
    log.SetFlags(0)                                                             
    http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {       
        c, err := upgrader.Upgrade(w, req, nil)                                 
        if err != nil {                                                         
            log.Print("upgrade:", err)                                          
            return                                                              
        }                                                                       
        defer c.Close()                                                         
        for {                                                                   
            mt, message, err := c.ReadMessage()                                 
            if err != nil {                                                     
                log.Println("read:", err)                                       
                break                                                           
            }                                                                   
            log.Printf("recv: %s", message)                                     
            err = c.WriteMessage(mt, message)                                   
            if err != nil {                                                     
                log.Println("write:", err)                                      
                break                                                           
            }                                                                   
        }                                                                       
    })                                                                          
                                                                                
    cert := "server.crt"                                                        
    key := "server.key"                                                         
                                                                                
    log.Fatal(http.ListenAndServeTLS(*addr, cert, key, nil))                    
}
```