### PR TITLE
kafka bugfix: heartbeat error not handled when callback

### DIFF
--- a/src/client/WFKafkaClient.cc
+++ b/src/client/WFKafkaClient.cc
@@ -260,7 +260,6 @@ void KafkaClientTask::kafka_rebalance_callback(__WFKafkaTask *task)
 		return;
 	}
 
-	int error = task->get_error();
 	if (task->get_state() == WFT_STATE_SUCCESS)
 	{
 		member->cgroup_status = KAFKA_CGROUP_DONE;

--- a/src/factory/KafkaTaskImpl.cc
+++ b/src/factory/KafkaTaskImpl.cc
@@ -772,7 +772,6 @@ bool __ComplexKafkaTask::finish_once()
 		this->disable_retry();
 		this->get_resp()->set_api_type(this->get_req()->get_api_type());
 		this->get_resp()->set_api_version(this->get_req()->get_api_version());
-		this->get_resp()->duplicate(*this->get_req());
 	}
 
 	if (ctx_.cb)


### PR DESCRIPTION
In order to remove parallel write of cgroup,
we set another cgroup instance in task's response, and handle resp->cgroup()->get_error() in callback. But in __ComplexKafkaTask::finish_once, resp's cgroup is overwriten by req's cgroup, so callback cannot handle this error.