### PR TITLE
class PolicyAddrParams needs polymorphism

### DIFF
--- a/src/nameservice/WFServiceGovernance.h
+++ b/src/nameservice/WFServiceGovernance.h
@@ -71,6 +71,8 @@ public:
 
 	PolicyAddrParams();
 	PolicyAddrParams(const struct AddressParams *params);
+
+	virtual ~PolicyAddrParams() = default;
 };
 
 class EndpointAddress


### PR DESCRIPTION
~PolicyAddrParams called in ~EndpointAddress must destroy derived classes