### PR TITLE
EndpointParams::address_family, set family for domain name resolution

### DIFF
--- a/src/manager/EndpointParams.h
+++ b/src/manager/EndpointParams.h
@@ -39,7 +39,7 @@ enum TransportType
 struct EndpointParams
 {
 	int address_family;
-	unsigned int max_connections;
+	int max_connections;
 	int connect_timeout;
 	int response_timeout;
 	int ssl_connect_timeout;

--- a/src/manager/EndpointParams.h
+++ b/src/manager/EndpointParams.h
@@ -19,7 +19,8 @@
 #ifndef _ENDPOINTPARAMS_H_
 #define _ENDPOINTPARAMS_H_
 
-#include <stddef.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 /**
  * @file   EndpointParams.h
@@ -37,7 +38,8 @@ enum TransportType
 
 struct EndpointParams
 {
-	size_t max_connections;
+	int address_family;
+	unsigned int max_connections;
 	int connect_timeout;
 	int response_timeout;
 	int ssl_connect_timeout;
@@ -46,6 +48,7 @@ struct EndpointParams
 
 static constexpr struct EndpointParams ENDPOINT_PARAMS_DEFAULT =
 {
+	.address_family			=	AF_UNSPEC,
 	.max_connections		=	200,
 	.connect_timeout		=	10 * 1000,
 	.response_timeout		=	10 * 1000,

--- a/src/manager/RouteManager.cc
+++ b/src/manager/RouteManager.cc
@@ -404,14 +404,18 @@ static uint64_t __generate_key(enum TransportType type,
 							   const std::string& hostname)
 {
 	std::string buf((const char *)&type, sizeof (enum TransportType));
-	unsigned int max_conn = ep_params->max_connections;
 
 	if (!other_info.empty())
 		buf += other_info;
 
-	buf.append((const char *)&max_conn, sizeof (unsigned int));
-	buf.append((const char *)&ep_params->connect_timeout, sizeof (int));
-	buf.append((const char *)&ep_params->response_timeout, sizeof (int));
+	int params[] = {
+		ep_params->address_family,
+		(int)ep_params->max_connections,
+		ep_params->connect_timeout,
+		ep_params->response_timeout
+	};
+
+	buf.append((const char *)params, sizeof params);
 	if (type == TT_TCP_SSL)
 	{
 		buf.append((const char *)&ep_params->ssl_connect_timeout, sizeof (int));
@@ -514,7 +518,7 @@ int RouteManager::get(enum TransportType type,
 			.addrinfo 				=	addrinfo,
 			.key					=	key,
 			.ssl_ctx				=	ssl_ctx,
-			.max_connections		=	(unsigned int)ep_params->max_connections,
+			.max_connections		=	ep_params->max_connections,
 			.connect_timeout		=	ep_params->connect_timeout,
 			.response_timeout		=	ep_params->response_timeout,
 			.ssl_connect_timeout	=	ssl_connect_timeout,

--- a/src/manager/RouteManager.cc
+++ b/src/manager/RouteManager.cc
@@ -106,7 +106,7 @@ struct RouteParams
 	const struct addrinfo *addrinfo;
 	uint64_t key;
 	SSL_CTX *ssl_ctx;
-	unsigned int max_connections;
+	int max_connections;
 	int connect_timeout;
 	int response_timeout;
 	int ssl_connect_timeout;
@@ -410,7 +410,7 @@ static uint64_t __generate_key(enum TransportType type,
 
 	int params[] = {
 		ep_params->address_family,
-		(int)ep_params->max_connections,
+		ep_params->max_connections,
 		ep_params->connect_timeout,
 		ep_params->response_timeout
 	};


### PR DESCRIPTION
当进行域名解析时，`WFDnsResolver`会根据本机是否有IPv4或IPv6地址来确定在解析域名时是否解析其IPv4或IPv6地址。在某些环境下，虽然本机有某种地址，但无法用于与外部网络通信，此时若解析出该类型的地址，在进行网络任务时会出现请求失败的情况。
该改动新增一项`EndpointParams::address_family`参数，可由用户指定使用哪种`address family`，可选的值有`AF_UNSPEC`、`AF_INET`、`AF_INET6`，默认值为`AF_UNSPEC`。