### PR TITLE
follow dns_server_params.address_family when parse nameserver

### DIFF
--- a/src/manager/WFGlobal.cc
+++ b/src/manager/WFGlobal.cc
@@ -510,7 +510,7 @@ static std::string __dns_server_url(const std::string& url,
 }
 
 static void __split_merge_str(const char *p, bool is_nameserver,
-							  struct addrinfo *hints,
+							  const struct addrinfo *hints,
 							  std::string& result)
 {
 	const char *start;

--- a/src/manager/WFGlobal.cc
+++ b/src/manager/WFGlobal.cc
@@ -40,6 +40,7 @@
 #include "WFTaskError.h"
 #include "WFDnsClient.h"
 #include "WFGlobal.h"
+#include "URIParser.h"
 
 class __WFGlobal
 {
@@ -478,7 +479,51 @@ inline ExecQueue *__ExecManager::get_exec_queue(const std::string& queue_name)
 	return queue;
 }
 
+static std::string __dns_server_url(const std::string& url,
+									struct addrinfo *hints)
+{
+	struct addrinfo *res;
+	int ret;
+
+	ret = getaddrinfo(url.c_str(), "53", hints, &res);
+	if (ret == 0)
+	{
+		int family = res->ai_family;
+		freeaddrinfo(res);
+
+		if (family != AF_INET6)
+			return url;
+		else
+			return "[" + url + "]";
+	}
+	else if (ret == EAI_ADDRFAMILY)
+		return "";
+
+	std::string host;
+	ParsedURI uri;
+
+	if (strncasecmp(url.c_str(), "dns://", 6) != 0 &&
+		strncasecmp(url.c_str(), "dnss://", 7) != 0)
+	{
+		host = "dns://" + url;
+	}
+	else
+		host = url;
+
+	if (URIParser::parse(host, uri) == 0 && uri.host && uri.host[0])
+	{
+		if (getaddrinfo(uri.host, "53", hints, &res) == 0)
+		{
+			freeaddrinfo(res);
+			return url;
+		}
+	}
+
+	return "";
+}
+
 static void __split_merge_str(const char *p, bool is_nameserver,
+							  struct addrinfo *hints,
 							  std::string& result)
 {
 	const char *start;
@@ -498,18 +543,17 @@ static void __split_merge_str(const char *p, bool is_nameserver,
 		if (start == p)
 			break;
 
-		if (!result.empty())
-			result.push_back(',');
-
 		std::string str(start, p);
 		if (is_nameserver)
-		{
-			struct in6_addr buf;
-			if (inet_pton(AF_INET6, str.c_str(), &buf) > 0)
-				str = "[" + str + "]";
-		}
+			str = __dns_server_url(str, hints);
 
-		result.append(str);
+		if (!str.empty())
+		{
+			if (!result.empty())
+				result.push_back(',');
+
+			result.append(str);
+		}
 	}
 }
 
@@ -565,12 +609,19 @@ static int __parse_resolv_conf(const char *path,
 	if (!fp)
 		return -1;
 
+	const struct WFGlobalSettings *settings = WFGlobal::get_global_settings();
+	struct addrinfo hints = {
+		.ai_flags		=	AI_ADDRCONFIG | AI_NUMERICHOST | AI_NUMERICSERV,
+		.ai_family		=	settings->dns_server_params.address_family,
+		.ai_socktype	=	SOCK_STREAM,
+	};
+
 	while ((ret = getline(&line, &bufsize, fp)) > 0)
 	{
 		if (strncmp(line, "nameserver", 10) == 0)
-			__split_merge_str(line + 10, true, url);
+			__split_merge_str(line + 10, true, &hints, url);
 		else if (strncmp(line, "search", 6) == 0)
-			__split_merge_str(line + 6, false, search_list);
+			__split_merge_str(line + 6, false, &hints, search_list);
 		else if (strncmp(line, "options", 7) == 0)
 			__set_options(line + 7, ndots, attempts, rotate);
 	}


### PR DESCRIPTION
在解析resolv.conf的nameserver条目时，依据`WFGlobalSettings::dns_server_params.address_family`的类型选择部分或全部可支持的server地址，相比系统配置，Workflow支持更多格式的nameserver地址

```
127.0.0.1
127.0.0.1:53
dns://127.0.0.1/
dns://127.0.0.1:53/
dnss://127.0.0.1/
dnss://127.0.0.1:53/

::1
[::1]:53
dns://[::1]
dns://[::1]:53
dnss://[::1]
dnss://[::1]:53

::ffff:127.0.0.1
[::ffff:127.0.0.1]:53
dns://[::ffff:127.0.0.1]/
dns://[::ffff:127.0.0.1]:53/
dnss://[::ffff:127.0.0.1]/
dnss://[::ffff:127.0.0.1]:53/
```