### PR TITLE
fix the bug that go_task may call empty function

### DIFF
--- a/src/factory/WFTaskFactory.inl
+++ b/src/factory/WFTaskFactory.inl
@@ -577,7 +577,9 @@ public:
 protected:
 	virtual void execute()
 	{
-		this->go();
+		if (this->go) {
+			this->go();
+		}
 	}
 
 protected:


### PR DESCRIPTION
`create_go_task`允许传入nullptr，但是执行时没有检测