### PR TITLE
Support add dns record, so we can make a real dns server

### DIFF
--- a/src/protocol/DnsMessage.h
+++ b/src/protocol/DnsMessage.h
@@ -153,8 +153,8 @@ public:
 	}
 
 	int add_a_record(int section, const char *name,
-					uint16_t rclass, uint32_t ttl,
-					const void *data)
+					 uint16_t rclass, uint32_t ttl,
+					 const void *data)
 	{
 		struct list_head *list = get_section(section);
 

--- a/src/protocol/DnsMessage.h
+++ b/src/protocol/DnsMessage.h
@@ -152,6 +152,109 @@ public:
 		parser->question.qname = strdup(name.c_str());
 	}
 
+	int add_a_record(int section, const char *name,
+					uint16_t rclass, uint32_t ttl,
+					const void *data)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_raw_record(name, DNS_TYPE_A, rclass, ttl, 4, data, list);
+	}
+
+	int add_aaaa_record(int section, const char *name,
+						uint16_t rclass, uint32_t ttl,
+						const void *data)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_raw_record(name, DNS_TYPE_AAAA, rclass, ttl,
+								  16, data, list);
+	}
+
+	int add_ns_record(int section, const char *name,
+					  uint16_t rclass, uint32_t ttl,
+					  const char *data)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_str_record(name, DNS_TYPE_NS, rclass, ttl, data, list);
+	}
+
+	int add_cname_record(int section, const char *name,
+						 uint16_t rclass, uint32_t ttl,
+						 const char *data)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_str_record(name, DNS_TYPE_CNAME, rclass, ttl,
+								  data, list);
+	}
+
+	int add_ptr_record(int section, const char *name,
+					   uint16_t rclass, uint32_t ttl,
+					   const char *data)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_str_record(name, DNS_TYPE_PTR, rclass, ttl, data, list);
+	}
+
+	int add_soa_record(int section, const char *name,
+					   uint16_t rclass, uint32_t ttl,
+					   const char *mname, const char *rname,
+					   uint32_t serial, int32_t refresh,
+					   int32_t retry, int32_t expire, uint32_t minimum)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_soa_record(name, rclass, ttl, mname, rname, serial,
+								  refresh, retry, expire, minimum, list);
+	}
+
+	int add_srv_record(int section, const char *name,
+					   uint16_t rclass, uint32_t ttl,
+					   uint16_t priority, uint16_t weight, uint16_t port,
+					   const char *target)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_srv_record(name, rclass, ttl,
+								  priority, weight, port, target, list);
+	}
+
+	int add_mx_record(int section, const char *name,
+					  uint16_t rclass, uint32_t ttl,
+					  int16_t preference, const char *exchange)
+	{
+		struct list_head *list = get_section(section);
+
+		if (!list)
+			return -1;
+
+		return dns_add_mx_record(name, rclass, ttl, preference, exchange, list);
+	}
+
 	// Inner use only
 	bool is_single_packet() const
 	{
@@ -190,6 +293,22 @@ protected:
 private:
 	int encode_reply();
 	int encode_truncation_reply();
+
+	struct list_head *get_section(int section)
+	{
+		switch (section)
+		{
+		case DNS_ANSWER_SECTION:
+			return &(parser->answer_list);
+		case DNS_AUTHORITY_SECTION:
+			return &(parser->authority_list);
+		case DNS_ADDITIONAL_SECTION:
+			return &(parser->additional_list);
+		default:
+			errno = EINVAL;
+			return NULL;
+		}
+	}
 
 	// size of msgbuf, but in network byte order
 	uint16_t msgsize;

--- a/src/protocol/dns_parser.c
+++ b/src/protocol/dns_parser.c
@@ -100,10 +100,15 @@ static int __dns_parser_parse_host(char *phost, dns_parser_t *parser)
 		else if ((len & 0xC0) == 0xC0)
 		{
 			pointer = __dns_parser_uint16(*cur) & 0x3FFF;
-			*cur += 2;
 
 			if (pointer >= parser->msgsize)
 				return -2;
+
+			// pointer must point to a prior position
+			if ((const char *)parser->msgbase + pointer >= *cur)
+				return -2;
+
+			*cur += 2;
 
 			// backup cur only when the first pointer occurs
 			if (curbackup == NULL)

--- a/src/protocol/dns_parser.c
+++ b/src/protocol/dns_parser.c
@@ -909,6 +909,186 @@ int dns_record_cursor_find_cname(const char *name,
 	return 1;
 }
 
+int dns_add_raw_record(const char *name, uint16_t type, uint16_t rclass,
+					   uint32_t ttl, uint16_t rlen, const void *rdata,
+					   struct list_head *list)
+{
+	struct __dns_record_entry *entry;
+	size_t entry_size = sizeof (struct __dns_record_entry) + rlen;
+
+	entry = (struct __dns_record_entry *)malloc(entry_size);
+	if (!entry)
+		return -1;
+
+	entry->record.name = strdup(name);
+	if (!entry->record.name)
+	{
+		free(entry);
+		return -1;
+	}
+
+	entry->record.type = type;
+	entry->record.rclass = rclass;
+	entry->record.ttl = ttl;
+	entry->record.rdlength = rlen;
+	entry->record.rdata = (void *)(entry + 1);
+	memcpy(entry->record.rdata, rdata, rlen);
+	list_add_tail(&entry->entry_list, list);
+
+	return 0;
+}
+
+int dns_add_str_record(const char *name, uint16_t type, uint16_t rclass,
+					   uint32_t ttl, const char *rdata,
+					   struct list_head *list)
+{
+	size_t rlen = strlen(rdata);
+	// record.rdlength has no meaning for parsed record types, ignore its
+	// correctness, same for soa/srv/mx record
+	return dns_add_raw_record(name, type, rclass, ttl, rlen+1, rdata, list);
+}
+
+int dns_add_soa_record(const char *name, uint16_t rclass, uint32_t ttl,
+					   const char *mname, const char *rname,
+					   uint32_t serial, int32_t refresh,
+					   int32_t retry, int32_t expire, uint32_t minimum,
+					   struct list_head *list)
+{
+	struct __dns_record_entry *entry;
+	struct dns_record_soa *soa;
+	size_t entry_size;
+	char *pname, *pmname, *prname;
+
+	entry_size = sizeof (struct __dns_record_entry) +
+				 sizeof (struct dns_record_soa);
+
+	entry = (struct __dns_record_entry *)malloc(entry_size);
+	if (!entry)
+		return -1;
+
+	entry->record.rdata = (void *)(entry + 1);
+	entry->record.rdlength = 0;
+	soa = (struct dns_record_soa *)(entry->record.rdata);
+
+	pname = strdup(name);
+	pmname = strdup(mname);
+	prname = strdup(rname);
+
+	if (!pname || !pmname || !prname)
+	{
+		free(pname);
+		free(pmname);
+		free(prname);
+		free(entry);
+		return -1;
+	}
+
+	soa->mname = pmname;
+	soa->rname = prname;
+	soa->serial = serial;
+	soa->refresh = refresh;
+	soa->retry = retry;
+	soa->expire = expire;
+	soa->minimum = minimum;
+
+	entry->record.name = pname;
+	entry->record.type = DNS_TYPE_SOA;
+	entry->record.rclass = rclass;
+	entry->record.ttl = ttl;
+	list_add_tail(&entry->entry_list, list);
+
+	return 0;
+}
+
+int dns_add_srv_record(const char *name, uint16_t rclass, uint32_t ttl,
+					   uint16_t priority, uint16_t weight,
+					   uint16_t port, const char *target,
+					   struct list_head *list)
+{
+	struct __dns_record_entry *entry;
+	struct dns_record_srv *srv;
+	size_t entry_size;
+	char *pname, *ptarget;
+
+	entry_size = sizeof (struct __dns_record_entry) +
+				 sizeof (struct dns_record_srv);
+
+	entry = (struct __dns_record_entry *)malloc(entry_size);
+	if (!entry)
+		return -1;
+
+	entry->record.rdata = (void *)(entry + 1);
+	entry->record.rdlength = 0;
+	srv = (struct dns_record_srv *)(entry->record.rdata);
+
+	pname = strdup(name);
+	ptarget = strdup(target);
+
+	if (!pname || !ptarget)
+	{
+		free(pname);
+		free(ptarget);
+		free(entry);
+		return -1;
+	}
+
+	srv->priority = priority;
+	srv->weight = weight;
+	srv->port = port;
+	srv->target = ptarget;
+
+	entry->record.name = pname;
+	entry->record.type = DNS_TYPE_SRV;
+	entry->record.rclass = rclass;
+	entry->record.ttl = ttl;
+	list_add_tail(&entry->entry_list, list);
+
+	return 0;
+}
+
+int dns_add_mx_record(const char *name, uint16_t rclass, uint32_t ttl,
+					  int16_t preference, const char *exchange,
+					  struct list_head *list)
+{
+	struct __dns_record_entry *entry;
+	struct dns_record_mx *mx;
+	size_t entry_size;
+	char *pname, *pexchange;
+
+	entry_size = sizeof (struct __dns_record_entry) +
+				 sizeof (struct dns_record_mx);
+
+	entry = (struct __dns_record_entry *)malloc(entry_size);
+	if (!entry)
+		return -1;
+
+	entry->record.rdata = (void *)(entry + 1);
+	entry->record.rdlength = 0;
+	mx = (struct dns_record_mx *)(entry->record.rdata);
+
+	pname = strdup(name);
+	pexchange = strdup(exchange);
+
+	if (!pname || !pexchange)
+	{
+		free(pname);
+		free(pexchange);
+		free(entry);
+		return -1;
+	}
+
+	mx->preference = preference;
+	mx->exchange = pexchange;
+
+	entry->record.name = pname;
+	entry->record.type = DNS_TYPE_MX;
+	entry->record.rclass = rclass;
+	entry->record.ttl = ttl;
+	list_add_tail(&entry->entry_list, list);
+
+	return 0;
+}
+
 const char *dns_type2str(int type)
 {
 	switch (type)

--- a/src/protocol/dns_parser.h
+++ b/src/protocol/dns_parser.h
@@ -78,6 +78,13 @@ enum
 	DNS_RCODE_REFUSED
 };
 
+enum
+{
+	DNS_ANSWER_SECTION = 1,
+	DNS_AUTHORITY_SECTION = 2,
+	DNS_ADDITIONAL_SECTION = 3,
+};
+
 /**
  * dns_header_t is a struct to describe the header of a dns
  * request or response packet, but the byte order is not
@@ -206,6 +213,29 @@ int dns_record_cursor_next(struct dns_record **record,
 int dns_record_cursor_find_cname(const char *name,
 								 const char **cname,
 								 dns_record_cursor_t *cursor);
+
+int dns_add_raw_record(const char *name, uint16_t type, uint16_t rclass,
+					   uint32_t ttl, uint16_t rlen, const void *rdata,
+					   struct list_head *list);
+
+int dns_add_str_record(const char *name, uint16_t type, uint16_t rclass,
+					   uint32_t ttl, const char *rdata,
+					   struct list_head *list);
+
+int dns_add_soa_record(const char *name, uint16_t rclass, uint32_t ttl,
+					   const char *mname, const char *rname,
+					   uint32_t serial, int32_t refresh,
+					   int32_t retry, int32_t expire, uint32_t minimum,
+					   struct list_head *list);
+
+int dns_add_srv_record(const char *name, uint16_t rclass, uint32_t ttl,
+					   uint16_t priority, uint16_t weight,
+					   uint16_t port, const char *target,
+					   struct list_head *list);
+
+int dns_add_mx_record(const char *name, uint16_t rclass, uint32_t ttl,
+					  int16_t preference, const char *exchange,
+					  struct list_head *list);
 
 const char *dns_type2str(int type);
 const char *dns_class2str(int dnsclass);


### PR DESCRIPTION
支持常见DNS记录类型`A`、`AAAA`、`NS`、`CNAME`、`PTR`、`SOA`、`SRV`、`MX`添加记录到`DnsMessage`，这样就可以创建真正的DNS服务器了。目前`encode`阶段缺少对`RFC 1035 [4.1.4] Message compression`的支持，虽然该特性并非强制。

附一个示例，仅展示使用方法，它对任意`name`都返回同样的内容

```cpp
#include <string>
#include <cstdio>
#include <arpa/inet.h>

#include "workflow/WFDnsServer.h"

using namespace std;

void process(WFDnsTask *task)
{
    protocol::DnsRequest *req = task->get_req();
    protocol::DnsResponse *resp = task->get_resp();

    std::string name = task->get_req()->get_question_name();

    int qtype = req->get_question_type();
    int qclass = req->get_question_class();

    printf("request name:%s type:%s class:%s\n",
           name.c_str(),
           dns_type2str(qtype),
           dns_class2str(qclass));

    resp->set_question_class(req->get_question_class());
    resp->set_question_type(req->get_question_type());
    resp->set_question_name(name);

    resp->set_id(req->get_id());
    resp->set_qr(1); // this is a response
    resp->set_opcode(req->get_opcode());
    resp->set_aa(0); // this is not a authoritative answer
    resp->set_rd(req->get_rd());
    resp->set_ra(0); // not support recursive query

    resp->set_rcode(DNS_RCODE_NO_ERROR);

    if (qtype == DNS_TYPE_A) {
        std::string cname = "what.a.very.long.cname.it.is";
        resp->add_cname_record(DNS_ANSWER_SECTION,
                               name.c_str(), DNS_CLASS_IN, 999, cname.c_str());

        struct in_addr addr;

        inet_pton(AF_INET, "192.168.0.1", (void *)&addr);
        resp->add_a_record(DNS_ANSWER_SECTION,
                           cname.c_str(), DNS_CLASS_IN, 600, &addr);

        inet_pton(AF_INET, "192.168.0.2", (void *)&addr);
        resp->add_a_record(DNS_ANSWER_SECTION,
                           cname.c_str(), DNS_CLASS_IN, 580, &addr);
    }
    else if (qtype == DNS_TYPE_AAAA) {
        struct in6_addr addr;

        inet_pton(AF_INET6, "2001::127.0.0.1", (void *)&addr);
        resp->add_aaaa_record(DNS_ANSWER_SECTION,
                              name.c_str(), DNS_CLASS_IN, 600, &addr);

        inet_pton(AF_INET6, "2001::900d:beef", (void *)&addr);
        resp->add_aaaa_record(DNS_ANSWER_SECTION,
                              name.c_str(), DNS_CLASS_IN, 10086, &addr);

        inet_pton(AF_INET6, "2001::c001:face", (void *)&addr);
        resp->add_aaaa_record(DNS_ANSWER_SECTION,
                              name.c_str(), DNS_CLASS_IN, 10086, &addr);
    }
    else if (qtype == DNS_TYPE_SOA) {
        const char *mname = "i.dont.know.what.is.this";
        const char *rname = "i.dont.know.what.is.this.too.";

        resp->add_soa_record(DNS_ANSWER_SECTION, name.c_str(), DNS_CLASS_IN, 998,
                             mname, rname, 1111, 2222, 3333, 4444, 5555);

        resp->add_mx_record(DNS_ADDITIONAL_SECTION, name.c_str(), DNS_CLASS_IN, 123,
                            456, "mail01.workflow.com");

        resp->add_ns_record(DNS_AUTHORITY_SECTION, name.c_str(), DNS_CLASS_IN, 123,
                            "b.root-servers.net");
    }
    else {
        resp->set_rcode(DNS_RCODE_NOT_IMPLEMENTED);
    }
}

int main() {
    WFDnsServer server(process);

    if (server.start(8053) == 0) {
        getchar();
        server.stop();
    }

    return 0;
}
```