### PR TITLE
[ENH] .gitignore: add ignore for so.version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Compiled Dynamic libraries
 *.so
+*.so.*
 *.dylib
 *.dll
 


### PR DESCRIPTION
```
➜  workflow git:(master) ✗ git st 
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        _lib/

nothing added to commit but untracked files present (use "git add" to track)
➜  workflow git:(master) ✗ ls _lib 
libworkflow.a  libworkflow.so  libworkflow.so.0  libworkflow.so.0.11.4
```

@Barenboim 

i notice some _lib are not exclueded, maybe this should done in .gitignore